### PR TITLE
Fix indentation in the cronjob template

### DIFF
--- a/openshift/cronJob-template.yaml
+++ b/openshift/cronJob-template.yaml
@@ -39,6 +39,7 @@ objects:
                 app: thoth
                 component: cve-update
             spec:
+              restartPolicy: OnFailure
               containers:
                 - image: cve-update-job
                   name: cve-update
@@ -68,7 +69,6 @@ objects:
                     limits:
                       memory: "128Mi"
                       cpu: "250m"
-                  restartPolicy: OnFailure
 
 parameters:
   - displayName: Suspend CronJob run


### PR DESCRIPTION
Fixes deployment failure:

```console
error: CronJob.batch "cve-update" is invalid: spec.jobTemplate.spec.template.spec.restartPolicy: Unsupported value: "Always"
```