### PR TITLE
Update zuul pipeline to use the new version trigger build job

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -10,7 +10,9 @@
       jobs:
         - trigger-build:
             vars:
-              webhook_url: "https://paas.upshift.redhat.com/oapi/v1/namespaces/thoth-test-core/buildconfigs/cve-update-job"
+              cluster: "paas.psi.redhat.com"
+              namespace: "thoth-test-core"
+              buildConfigName: "cve-update-job"
     kebechet-auto-gate:
       queue: "thoth-station/core"
       jobs:

--- a/openshift/buildConfig-template.yaml
+++ b/openshift/buildConfig-template.yaml
@@ -59,7 +59,10 @@ objects:
       triggers:
         - imageChange: {}
           type: ImageChange
-
+        - type: "Generic"
+          generic:
+            secretReference:
+              name: generic-webhook-secret
 parameters:
   - description: Git repository for Thoth's CVE Update Job
     displayName: Thoth CVE Update Job git repository


### PR DESCRIPTION
Update generic trigger to buildconfig to use new generic webhook secret.
The generic-webhook-secret secret is a prerequisite for using this new build config.
Update the zuul config to use the new trigger build job API in zuul-config.