### PR TITLE
Update logic to conform OSV 0.8 format used now

### DIFF
--- a/app.py
+++ b/app.py
@@ -95,44 +95,50 @@ def _record_vulnerability(
     """Record the given vulnerability in the database."""
     _LOGGER.info("Creating CVE entries for %r...", vulnerability["id"])
 
-    if not vulnerability["affects"].get("versions"):
-        _LOGGER.warning("No versions found for CVE %r", vulnerability["id"])
-        return 0
-
-    package_name = vulnerability["package"]["name"]
     cve_id = vulnerability["id"]
-    for package_version in vulnerability["affects"]["versions"]:
-        existed = graph.create_python_cve_record(
-            package_name,
-            package_version,
-            "https://pypi.org/simple",
-            cve_id=cve_id,
-            details=vulnerability["details"],
-        )
-
-        if existed:
+    for affected in vulnerability.get("affected") or []:
+        if affected["package"]["ecosystem"] != "PyPI":
+            _LOGGER.info(
+                "Skipping affected package %r from ecosystem %r",
+                affected["package"]["name"],
+                affected["package"]["ecosystem"],
+            )
             continue
 
-        _LOGGER.info(
-            "Created new CVE %r entry for package %r in version %r",
-            cve_id,
-            package_name,
-            package_version,
-        )
+        package_name = affected["package"]["name"]
 
-        publish_to_topic(
-            _PRODUCER,
-            cve_provided_message,
-            CVEProvidedMessageContent(
-                component_name=_COMPONENT_NAME,
-                service_version=__component_version__,
-                package_name=package_name,
-                package_version=package_version,
-                index_url="https://pypi.org/simple",
-            ),
-        )
+        for package_version in affected.get("versions") or []:
+            existed = graph.create_python_cve_record(
+                package_name,
+                package_version,
+                "https://pypi.org/simple",
+                cve_id=cve_id,
+                details=vulnerability["details"],
+            )
 
-        cve_messages_sent += 1
+            if existed:
+                continue
+
+            _LOGGER.info(
+                "Created new CVE %r entry for package %r in version %r",
+                cve_id,
+                package_name,
+                package_version,
+            )
+
+            publish_to_topic(
+                _PRODUCER,
+                cve_provided_message,
+                CVEProvidedMessageContent(
+                    component_name=_COMPONENT_NAME,
+                    service_version=__component_version__,
+                    package_name=package_name,
+                    package_version=package_version,
+                    index_url="https://pypi.org/simple",
+                ),
+            )
+
+            cve_messages_sent += 1
 
     return cve_messages_sent
 


### PR DESCRIPTION
advisory-db now uses OSV 0.8 format for all the entries. We need to adopt this format to make the job work properly, see - https://github.com/pypa/advisory-db/commit/7872b0a91b4d980f749e6d75a81f8cc1af32829f