### PR TITLE
Fix the labels in the issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-labels: bug
+labels: kind/bug
 ---
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-labels: enhancement
+labels: kind/feature
 ---
 
 **Is your feature request related to a problem? Please describe.**


### PR DESCRIPTION
The bug and feature templates have outdated labels.

This results in that new issues don't get the right `kind/` label, see for example https://github.com/thoth-station/cve-update-job/issues/438#issuecomment-951920492

This fixes these labels in the templates