### PR TITLE
Fix metrics overflow

### DIFF
--- a/app.py
+++ b/app.py
@@ -111,12 +111,11 @@ def _get_vulnerability_link(vulnerability: Dict[str, Any]) -> Optional[str]:
     return link
 
 
-def _record_vulnerability(
-    graph: GraphDatabase, vulnerability: Dict[str, Any], cve_messages_sent: int
-) -> int:
+def _record_vulnerability(graph: GraphDatabase, vulnerability: Dict[str, Any]) -> int:
     """Record the given vulnerability in the database."""
     _LOGGER.info("Creating CVE entries for %r...", vulnerability["id"])
 
+    cve_messages_sent = 0
     cve_id = vulnerability["id"]
     for affected in vulnerability.get("affected") or []:
         if affected["package"]["ecosystem"] != "PyPI":
@@ -182,7 +181,6 @@ def cli(advisory_db: str) -> None:
     with tempfile.TemporaryDirectory() as repo_dir:
         Repo.clone_from(advisory_db, repo_dir, depth=1)
         vulnerabilities_dir = os.path.join(repo_dir, "vulns")
-        cve_messages_sent = 0
         for package_name in os.listdir(os.path.join(vulnerabilities_dir)):
             if package_name.startswith("."):
                 continue
@@ -206,8 +204,12 @@ def cli(advisory_db: str) -> None:
                     )
                 else:
                     try:
-                        cve_messages_sent += _record_vulnerability(
-                            _GRAPH_DB, vulnerability_file_content, cve_messages_sent
+                        _METRIC_MESSSAGES_SENT.labels(
+                            message_type=cve_provided_message.topic_name,
+                            env=THOTH_DEPLOYMENT_NAME,
+                            version=__component_version__,
+                        ).inc(
+                            _record_vulnerability(_GRAPH_DB, vulnerability_file_content)
                         )
                     except Exception:
                         _LOGGER.exception(
@@ -215,27 +217,19 @@ def cli(advisory_db: str) -> None:
                             vulnerability_file_path,
                         )
 
-            _METRIC_MESSSAGES_SENT.labels(
-                message_type=cve_provided_message.topic_name,
-                env=THOTH_DEPLOYMENT_NAME,
-                version=__component_version__,
-            ).inc(cve_messages_sent)
-
-            if _THOTH_METRICS_PUSHGATEWAY_URL:
-                try:
-                    _LOGGER.debug(
-                        "Submitting metrics to Prometheus pushgateway %s",
-                        _THOTH_METRICS_PUSHGATEWAY_URL,
-                    )
-                    push_to_gateway(
-                        _THOTH_METRICS_PUSHGATEWAY_URL,
-                        job="cve-update",
-                        registry=prometheus_registry,
-                    )
-                except Exception as e:
-                    _LOGGER.exception(
-                        f"An error occurred pushing the metrics: {str(e)}"
-                    )
+        if _THOTH_METRICS_PUSHGATEWAY_URL:
+            try:
+                _LOGGER.debug(
+                    "Submitting metrics to Prometheus pushgateway %s",
+                    _THOTH_METRICS_PUSHGATEWAY_URL,
+                )
+                push_to_gateway(
+                    _THOTH_METRICS_PUSHGATEWAY_URL,
+                    job="cve-update",
+                    registry=prometheus_registry,
+                )
+            except Exception as e:
+                _LOGGER.exception(f"An error occurred pushing the metrics: {str(e)}")
 
     _LOGGER.info("Flushing pending messages")
     _PRODUCER.flush()


### PR DESCRIPTION
The cve count was added to itself multiples time over, instead of simply
incremented, which eventually caused exponential growth and an overflow.

## Related Issues and Dependencies
Fixes: #438

## This introduces a breaking change
- No

## This should yield a new module release

- Yes


## Bug explanation


```python

        cve_messages_sent = 0
        for package_name in os.listdir(os.path.join(vulnerabilities_dir)):
            if package_name.startswith("."):
                continue

            _LOGGER.info("Parsing vulnerabilities for %r", package_name)

            for vulnerability_file in os.listdir(
                os.path.join(vulnerabilities_dir, package_name)
            ):
                _LOGGER.info("Loading vulnerability file %r", vulnerability_file)
                vulnerability_file_path = os.path.join(
                    vulnerabilities_dir, package_name, vulnerability_file
                )
                try:
                    with open(vulnerability_file_path) as f:
                        vulnerability_file_content = yaml.safe_load(f)
                except Exception:
                    _LOGGER.exception(
                        "Failed to parse vulnerability file %r, skipping...",
                        vulnerability_file_path,
                    )
                else:
                    try:
                        # _record_vulnerability increment cve_messages_sent, using the original value 
                        # as start value. And we add it back to itself where.
                        # This is two (nested) loops, so we actually have something like cve_messages_sent^3
                        cve_messages_sent += _record_vulnerability(
                            _GRAPH_DB, vulnerability_file_content, cve_messages_sent
                        )
                    except Exception:
                        _LOGGER.exception(
                            "Failed to record vulnerability from file %r, skipping..",
                            vulnerability_file_path,
                        )

            _METRIC_MESSSAGES_SENT.labels(
                message_type=cve_provided_message.topic_name,
                env=THOTH_DEPLOYMENT_NAME,
                version=__component_version__,
            ).inc(cve_messages_sent)
            # This is also in a loop, and added each time. So the internal value of the counter prometheus is in cve_message_sent^4 magnitude

```
