### PR TITLE
Migrate flake8 settings to .flake8 file

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,10 @@
+[flake8]
+ignore =
+    E2,
+    W5
+select =
+    E,
+    W,
+    F,
+    N
+max-line-length=120

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,6 +53,3 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies: ["pep8-naming"]
-        # Ignore all format-related checks as Black takes care of those.
-        args:
-          ["--ignore", "E2,W5", "--select", "E,W,F,N", "--max-line-length=120"]


### PR DESCRIPTION
Having the setting here allow lsp other user of flake8
(python-lsp-server, in particular) to account for those settings
